### PR TITLE
feat: add show highlight option to preview settings

### DIFF
--- a/packages/renderer/src/components/EditorPage/component.tsx
+++ b/packages/renderer/src/components/EditorPage/component.tsx
@@ -287,6 +287,15 @@ function PreviewOptions({ onChange, options }: PreviewOptionsProps) {
           }
           label={t('editor.header.actions.preview_options.landscape_terrain_enabled')}
         />
+        <FormControlLabel
+          control={
+            <Checkbox
+              checked={!!options.showHighlight}
+              onChange={handleChange({ showHighlight: !options.showHighlight })}
+            />
+          }
+          label={t('editor.header.actions.preview_options.show_highlight')}
+        />
       </FormGroup>
     </div>
   );

--- a/packages/renderer/src/modules/store/translation/locales/en.json
+++ b/packages/renderer/src/modules/store/translation/locales/en.json
@@ -46,7 +46,8 @@
           "title": "Preview Options",
           "debugger": "Open Console Window during preview",
           "skip_auth_screen": "Skip Auth Screen",
-          "landscape_terrain_enabled": "Enable Landscape Terrains"
+          "landscape_terrain_enabled": "Enable Landscape Terrains",
+          "show_highlight": "Show Highlight On Clickable"
         },
         "publish_options": {
           "history": "Publishing History"

--- a/packages/shared/types/settings.ts
+++ b/packages/shared/types/settings.ts
@@ -10,6 +10,7 @@ export type PreviewOptions = {
   debugger: boolean;
   skipAuthScreen: boolean;
   enableLandscapeTerrains: boolean;
+  showHighlight?: boolean;
 };
 
 export type AppSettings = {


### PR DESCRIPTION
- Introduced a new checkbox for "Show Highlight On Clickable" in the preview options.
- Updated translation file to include the new label for the highlight option.
- Modified the PreviewOptions type to accommodate the new showHighlight property.